### PR TITLE
Make UI more compliant with Windows 11 design

### DIFF
--- a/NanaBox/App.xaml
+++ b/NanaBox/App.xaml
@@ -1,16 +1,16 @@
 ﻿<Application
-    x:Class="NanaBox.App"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:NanaBox">
-    <Application.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="ms-appx:///Mile.Xaml.Styles.SunValley.xbf" />
-            </ResourceDictionary.MergedDictionaries>
-            <Style TargetType="local:ProgressRing">
-                <Setter Property="Foreground" Value="{ThemeResource AccentFillColorDefaultBrush}" />
-            </Style>
-        </ResourceDictionary>
-    </Application.Resources>
+  x:Class="NanaBox.App"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:local="using:NanaBox">
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ms-appx:///Mile.Xaml.Styles.SunValley.xbf" />
+      </ResourceDictionary.MergedDictionaries>
+      <Style TargetType="local:ProgressRing">
+        <Setter Property="Foreground" Value="{ThemeResource AccentFillColorDefaultBrush}" />
+      </Style>
+    </ResourceDictionary>
+  </Application.Resources>
 </Application>

--- a/NanaBox/App.xaml
+++ b/NanaBox/App.xaml
@@ -1,13 +1,16 @@
 ﻿<Application
-  x:Class="NanaBox.App"
-  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:local="using:NanaBox">
-  <Application.Resources>
-    <ResourceDictionary>
-      <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///Mile.Xaml.Styles.SunValley.xbf" />
-      </ResourceDictionary.MergedDictionaries>
-    </ResourceDictionary>
-  </Application.Resources>
+    x:Class="NanaBox.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:NanaBox">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ms-appx:///Mile.Xaml.Styles.SunValley.xbf" />
+            </ResourceDictionary.MergedDictionaries>
+            <Style TargetType="local:ProgressRing">
+                <Setter Property="Foreground" Value="{ThemeResource AccentFillColorDefaultBrush}" />
+            </Style>
+        </ResourceDictionary>
+    </Application.Resources>
 </Application>

--- a/NanaBox/NanaBox.vcxproj
+++ b/NanaBox/NanaBox.vcxproj
@@ -68,6 +68,10 @@
       <DependentUpon>NewVirtualHardDiskPage.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="ProgressRing.cpp">
+      <DependentUpon>ProgressRing.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="QuickStartPage.cpp">
       <DependentUpon>QuickStartPage.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -128,6 +132,9 @@
       <DependentUpon>NewVirtualHardDiskPage.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
+    <Midl Include="ProgressRing.idl">
+      <SubType>Code</SubType>
+    </Midl>
     <Midl Include="QuickStartPage.idl">
       <DependentUpon>QuickStartPage.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -175,6 +182,10 @@
       <SubType>Code</SubType>
     </ClInclude>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="ProgressRing.h">
+      <DependentUpon>ProgressRing.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="QuickStartPage.h">
       <DependentUpon>QuickStartPage.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/NanaBox/NanaBox.vcxproj.filters
+++ b/NanaBox/NanaBox.vcxproj.filters
@@ -18,6 +18,7 @@
     <ClCompile Include="RdpBase.cpp">
       <Filter>RdpClient</Filter>
     </ClCompile>
+    <ClCompile Include="NanaBox.Configuration.Parser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="NanaBox.manifest" />
@@ -45,6 +46,7 @@
     <ClInclude Include="RdpBase.h">
       <Filter>RdpClient</Filter>
     </ClInclude>
+    <ClInclude Include="NanaBox.Configuration.Parser.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="RdpClient">
@@ -153,5 +155,8 @@
     <PRIResource Include="Strings\zh-Hans\SponsorPage.resw">
       <Filter>Strings\zh-Hans</Filter>
     </PRIResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="ProgressRing.idl" />
   </ItemGroup>
 </Project>

--- a/NanaBox/NewVirtualHardDiskPage.xaml
+++ b/NanaBox/NewVirtualHardDiskPage.xaml
@@ -1,97 +1,97 @@
 ﻿<Page
-  x:Class="NanaBox.NewVirtualHardDiskPage"
-  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-  xmlns:local="using:NanaBox"
-  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-  IsTextScaleFactorEnabled="False"
-  mc:Ignorable="d">
-  <Grid>
-    <Grid.RowDefinitions>
-      <RowDefinition Height="*" />
-      <RowDefinition Height="Auto" />
-    </Grid.RowDefinitions>
-    <StackPanel Grid.Row="0" Padding="24,0">
-      <TextBlock
-        x:Uid="/NewVirtualHardDiskPage/GridTitleTextBlock"
-        Margin="0,0,0,12"
-        FontSize="24"
-        FontWeight="SemiBold"
-        Text="[Create Virtual Hard Disk]"
-        TextWrapping="Wrap" />
-      <TextBlock
-        x:Uid="/NewVirtualHardDiskPage/ContentTextBlock"
-        Text="[You can create a VHD (up to 2040 GiB) or VHDX (up to 64 TiB, but not supported before Windows 8) dynamically expanding virtual hard disk with this dialog.]"
-        TextWrapping="Wrap" />
-      <Grid Padding="0,2,0,0">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="auto" />
-        </Grid.ColumnDefinitions>
-        <TextBox
-          x:Name="FileNameTextBox"
-          x:Uid="/NewVirtualHardDiskPage/FileNameTextBox"
-          Grid.Column="0"
-          IsReadOnly="True"
-          PlaceholderText="[Please use &quot;...&quot; button to specify the save location.]" />
-        <Button
-          x:Name="FileNameBrowseButton"
-          Grid.Column="1"
-          Click="FileNameBrowseButtonClickHandler"
-          Content="..." />
-      </Grid>
-      <TextBlock
-        x:Uid="/NewVirtualHardDiskPage/SizeTextBlock"
-        Padding="0,2"
-        Text="Size (at least 3 MiB and must be a multiple of 512 bytes)" />
-      <Grid Padding="0,2,0,0">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="144" />
-        </Grid.ColumnDefinitions>
-        <TextBox
-          x:Name="SizeTextBox"
-          BeforeTextChanging="NaturalNumberTextBoxBeforeTextChanging"
-          Text="0" />
-        <ComboBox
-          x:Name="SizeUnitComboBox"
-          Grid.Column="1"
-          HorizontalAlignment="Stretch"
-          SelectedIndex="5">
-          <x:String>B</x:String>
-          <x:String>KB (1000 B)</x:String>
-          <x:String>KiB (1024 B)</x:String>
-          <x:String>MB (1000 KB)</x:String>
-          <x:String>MiB (1024 KiB)</x:String>
-          <x:String>GB (1000 MB)</x:String>
-          <x:String>GiB (1024 MiB)</x:String>
-          <x:String>TB (1000 GB)</x:String>
-          <x:String>TiB (1024 GiB)</x:String>
-        </ComboBox>
-      </Grid>
-    </StackPanel>
-    <Grid Grid.Row="1" Padding="24">
-      <Grid.Background>
-        <SolidColorBrush Opacity="0.2" Color="{ThemeResource SystemChromeHighColor}" />
-      </Grid.Background>
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="*" />
-        <ColumnDefinition Width="8" />
-        <ColumnDefinition Width="*" />
-      </Grid.ColumnDefinitions>
-      <Button
-        x:Uid="/NewVirtualHardDiskPage/CreateButton"
-        HorizontalAlignment="Stretch"
-        Click="CreateButtonClick"
-        Content="[Create]" />
-      <Button
-        x:Uid="/NewVirtualHardDiskPage/CancelButton"
-        Grid.Column="4"
-        HorizontalAlignment="Stretch"
-        Click="CancelButtonClick"
-        Content="[Cancel]"
-        TabIndex="1" />
+    x:Class="NanaBox.NewVirtualHardDiskPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:NanaBox"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    IsTextScaleFactorEnabled="False"
+    mc:Ignorable="d">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Padding="24,0">
+            <TextBlock
+                x:Uid="/NewVirtualHardDiskPage/GridTitleTextBlock"
+                Margin="0,0,0,12"
+                FontSize="24"
+                FontWeight="SemiBold"
+                Text="[Create Virtual Hard Disk]"
+                TextWrapping="Wrap" />
+            <TextBlock
+                x:Uid="/NewVirtualHardDiskPage/ContentTextBlock"
+                Text="[You can create a VHD (up to 2040 GiB) or VHDX (up to 64 TiB, but not supported before Windows 8) dynamically expanding virtual hard disk with this dialog.]"
+                TextWrapping="Wrap" />
+            <Grid Padding="0,2,0,0" ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="auto" />
+                </Grid.ColumnDefinitions>
+                <TextBox
+                    x:Name="FileNameTextBox"
+                    x:Uid="/NewVirtualHardDiskPage/FileNameTextBox"
+                    Grid.Column="0"
+                    IsReadOnly="True"
+                    PlaceholderText="[Please use &quot;...&quot; button to specify the save location.]" />
+                <Button
+                    x:Name="FileNameBrowseButton"
+                    Grid.Column="1"
+                    Click="FileNameBrowseButtonClickHandler"
+                    Content="..." />
+            </Grid>
+            <TextBlock
+                x:Uid="/NewVirtualHardDiskPage/SizeTextBlock"
+                Padding="0,2"
+                Text="Size (at least 3 MiB and must be a multiple of 512 bytes)" />
+            <Grid Padding="0,2,0,0" ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="144" />
+                </Grid.ColumnDefinitions>
+                <TextBox
+                    x:Name="SizeTextBox"
+                    BeforeTextChanging="NaturalNumberTextBoxBeforeTextChanging"
+                    Text="0" />
+                <ComboBox
+                    x:Name="SizeUnitComboBox"
+                    Grid.Column="1"
+                    HorizontalAlignment="Stretch"
+                    SelectedIndex="5">
+                    <x:String>B</x:String>
+                    <x:String>KB (1000 B)</x:String>
+                    <x:String>KiB (1024 B)</x:String>
+                    <x:String>MB (1000 KB)</x:String>
+                    <x:String>MiB (1024 KiB)</x:String>
+                    <x:String>GB (1000 MB)</x:String>
+                    <x:String>GiB (1024 MiB)</x:String>
+                    <x:String>TB (1000 GB)</x:String>
+                    <x:String>TiB (1024 GiB)</x:String>
+                </ComboBox>
+            </Grid>
+        </StackPanel>
+        <Grid Grid.Row="1" Padding="24">
+            <Grid.Background>
+                <SolidColorBrush Opacity="0.2" Color="{ThemeResource SystemChromeHighColor}" />
+            </Grid.Background>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="8" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Button
+                x:Uid="/NewVirtualHardDiskPage/CreateButton"
+                HorizontalAlignment="Stretch"
+                Click="CreateButtonClick"
+                Content="[Create]" />
+            <Button
+                x:Uid="/NewVirtualHardDiskPage/CancelButton"
+                Grid.Column="4"
+                HorizontalAlignment="Stretch"
+                Click="CancelButtonClick"
+                Content="[Cancel]"
+                TabIndex="1" />
+        </Grid>
     </Grid>
-  </Grid>
 </Page>

--- a/NanaBox/NewVirtualHardDiskPage.xaml
+++ b/NanaBox/NewVirtualHardDiskPage.xaml
@@ -1,97 +1,97 @@
 ﻿<Page
-    x:Class="NanaBox.NewVirtualHardDiskPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:NanaBox"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    IsTextScaleFactorEnabled="False"
-    mc:Ignorable="d">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <StackPanel Grid.Row="0" Padding="24,0">
-            <TextBlock
-                x:Uid="/NewVirtualHardDiskPage/GridTitleTextBlock"
-                Margin="0,0,0,12"
-                FontSize="24"
-                FontWeight="SemiBold"
-                Text="[Create Virtual Hard Disk]"
-                TextWrapping="Wrap" />
-            <TextBlock
-                x:Uid="/NewVirtualHardDiskPage/ContentTextBlock"
-                Text="[You can create a VHD (up to 2040 GiB) or VHDX (up to 64 TiB, but not supported before Windows 8) dynamically expanding virtual hard disk with this dialog.]"
-                TextWrapping="Wrap" />
-            <Grid Padding="0,2,0,0" ColumnSpacing="8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="auto" />
-                </Grid.ColumnDefinitions>
-                <TextBox
-                    x:Name="FileNameTextBox"
-                    x:Uid="/NewVirtualHardDiskPage/FileNameTextBox"
-                    Grid.Column="0"
-                    IsReadOnly="True"
-                    PlaceholderText="[Please use &quot;...&quot; button to specify the save location.]" />
-                <Button
-                    x:Name="FileNameBrowseButton"
-                    Grid.Column="1"
-                    Click="FileNameBrowseButtonClickHandler"
-                    Content="..." />
-            </Grid>
-            <TextBlock
-                x:Uid="/NewVirtualHardDiskPage/SizeTextBlock"
-                Padding="0,2"
-                Text="Size (at least 3 MiB and must be a multiple of 512 bytes)" />
-            <Grid Padding="0,2,0,0" ColumnSpacing="8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="144" />
-                </Grid.ColumnDefinitions>
-                <TextBox
-                    x:Name="SizeTextBox"
-                    BeforeTextChanging="NaturalNumberTextBoxBeforeTextChanging"
-                    Text="0" />
-                <ComboBox
-                    x:Name="SizeUnitComboBox"
-                    Grid.Column="1"
-                    HorizontalAlignment="Stretch"
-                    SelectedIndex="5">
-                    <x:String>B</x:String>
-                    <x:String>KB (1000 B)</x:String>
-                    <x:String>KiB (1024 B)</x:String>
-                    <x:String>MB (1000 KB)</x:String>
-                    <x:String>MiB (1024 KiB)</x:String>
-                    <x:String>GB (1000 MB)</x:String>
-                    <x:String>GiB (1024 MiB)</x:String>
-                    <x:String>TB (1000 GB)</x:String>
-                    <x:String>TiB (1024 GiB)</x:String>
-                </ComboBox>
-            </Grid>
-        </StackPanel>
-        <Grid Grid.Row="1" Padding="24">
-            <Grid.Background>
-                <SolidColorBrush Opacity="0.2" Color="{ThemeResource SystemChromeHighColor}" />
-            </Grid.Background>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="8" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Button
-                x:Uid="/NewVirtualHardDiskPage/CreateButton"
-                HorizontalAlignment="Stretch"
-                Click="CreateButtonClick"
-                Content="[Create]" />
-            <Button
-                x:Uid="/NewVirtualHardDiskPage/CancelButton"
-                Grid.Column="4"
-                HorizontalAlignment="Stretch"
-                Click="CancelButtonClick"
-                Content="[Cancel]"
-                TabIndex="1" />
-        </Grid>
+  x:Class="NanaBox.NewVirtualHardDiskPage"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:local="using:NanaBox"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  IsTextScaleFactorEnabled="False"
+  mc:Ignorable="d">
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+    <StackPanel Grid.Row="0" Padding="24,0">
+      <TextBlock
+        x:Uid="/NewVirtualHardDiskPage/GridTitleTextBlock"
+        Margin="0,0,0,12"
+        FontSize="24"
+        FontWeight="SemiBold"
+        Text="[Create Virtual Hard Disk]"
+        TextWrapping="Wrap" />
+      <TextBlock
+        x:Uid="/NewVirtualHardDiskPage/ContentTextBlock"
+        Text="[You can create a VHD (up to 2040 GiB) or VHDX (up to 64 TiB, but not supported before Windows 8) dynamically expanding virtual hard disk with this dialog.]"
+        TextWrapping="Wrap" />
+      <Grid Padding="0,2,0,0" ColumnSpacing="8">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="auto" />
+        </Grid.ColumnDefinitions>
+        <TextBox
+          x:Name="FileNameTextBox"
+          x:Uid="/NewVirtualHardDiskPage/FileNameTextBox"
+          Grid.Column="0"
+          IsReadOnly="True"
+          PlaceholderText="[Please use &quot;...&quot; button to specify the save location.]" />
+        <Button
+          x:Name="FileNameBrowseButton"
+          Grid.Column="1"
+          Click="FileNameBrowseButtonClickHandler"
+          Content="..." />
+      </Grid>
+      <TextBlock
+        x:Uid="/NewVirtualHardDiskPage/SizeTextBlock"
+        Padding="0,2"
+        Text="Size (at least 3 MiB and must be a multiple of 512 bytes)" />
+      <Grid Padding="0,2,0,0" ColumnSpacing="8">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="144" />
+        </Grid.ColumnDefinitions>
+        <TextBox
+          x:Name="SizeTextBox"
+          BeforeTextChanging="NaturalNumberTextBoxBeforeTextChanging"
+          Text="0" />
+        <ComboBox
+          x:Name="SizeUnitComboBox"
+          Grid.Column="1"
+          HorizontalAlignment="Stretch"
+          SelectedIndex="5">
+          <x:String>B</x:String>
+          <x:String>KB (1000 B)</x:String>
+          <x:String>KiB (1024 B)</x:String>
+          <x:String>MB (1000 KB)</x:String>
+          <x:String>MiB (1024 KiB)</x:String>
+          <x:String>GB (1000 MB)</x:String>
+          <x:String>GiB (1024 MiB)</x:String>
+          <x:String>TB (1000 GB)</x:String>
+          <x:String>TiB (1024 GiB)</x:String>
+        </ComboBox>
+      </Grid>
+    </StackPanel>
+    <Grid Grid.Row="1" Padding="24">
+      <Grid.Background>
+        <SolidColorBrush Opacity="0.2" Color="{ThemeResource SystemChromeHighColor}" />
+      </Grid.Background>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="8" />
+        <ColumnDefinition Width="*" />
+      </Grid.ColumnDefinitions>
+      <Button
+        x:Uid="/NewVirtualHardDiskPage/CreateButton"
+        HorizontalAlignment="Stretch"
+        Click="CreateButtonClick"
+        Content="[Create]" />
+      <Button
+        x:Uid="/NewVirtualHardDiskPage/CancelButton"
+        Grid.Column="4"
+        HorizontalAlignment="Stretch"
+        Click="CancelButtonClick"
+        Content="[Cancel]"
+        TabIndex="1" />
     </Grid>
+  </Grid>
 </Page>

--- a/NanaBox/ProgressRing.cpp
+++ b/NanaBox/ProgressRing.cpp
@@ -1,0 +1,114 @@
+﻿#include "pch.h"
+#include "ProgressRing.h"
+#if __has_include("ProgressRing.g.cpp")
+#include "ProgressRing.g.cpp"
+#endif
+
+namespace winrt::NanaBox::implementation
+{
+    ProgressRing::ProgressRing()
+    {
+        m_compositor = Windows::UI::Xaml::Hosting::ElementCompositionPreview::GetElementVisual(*this).Compositor();
+
+        auto ellipse = m_compositor.CreateEllipseGeometry();
+        ellipse.Radius({ 7, 7 });
+
+        m_shape = m_compositor.CreateSpriteShape(ellipse);
+        m_shape.StrokeDashCap(Windows::UI::Composition::CompositionStrokeCap::Round);
+        m_shape.StrokeStartCap(Windows::UI::Composition::CompositionStrokeCap::Round);
+        m_shape.StrokeEndCap(Windows::UI::Composition::CompositionStrokeCap::Round);
+        m_shape.StrokeThickness(m_strokeThickness);
+        m_shape.TransformMatrix({ 5.0f, 0.0f, 0.0f, 5.0f, 40.0f, 40.0f });
+
+        m_visual = m_compositor.CreateShapeVisual();
+        m_visual.Size({ m_defaultProgressRingSize, m_defaultProgressRingSize });
+        m_visual.Shapes().Append(m_shape);
+
+        Windows::UI::Xaml::Hosting::ElementCompositionPreview::SetElementChildVisual(*this, m_visual);
+
+        auto holdThenStepEasing = m_compositor.CreateStepEasingFunction();
+        holdThenStepEasing.IsFinalStepSingleFrame(true);
+
+        auto cubicBezierEasing = m_compositor.CreateCubicBezierEasingFunction({ 0.166999996f, 0.166999996f }, { 0.833000004f, 0.833000004f });
+
+        auto rotationAnimation = m_compositor.CreateScalarKeyFrameAnimation();
+        rotationAnimation.InsertKeyFrame(0.0f, 0.0f, holdThenStepEasing);
+        rotationAnimation.InsertKeyFrame(0.5f, 450.0f, cubicBezierEasing);
+        rotationAnimation.InsertKeyFrame(1.0f, 1080.0f, cubicBezierEasing);
+        rotationAnimation.Duration(Windows::Foundation::TimeSpan{ std::chrono::seconds(2) });
+        rotationAnimation.IterationBehavior(Windows::UI::Composition::AnimationIterationBehavior::Forever);
+
+        auto sizeAnimation = m_compositor.CreateScalarKeyFrameAnimation();
+        sizeAnimation.InsertKeyFrame(0.0f, 0.0f, holdThenStepEasing);
+        sizeAnimation.InsertKeyFrame(0.5f, 0.5f, cubicBezierEasing);
+        sizeAnimation.InsertKeyFrame(1.0f, 0.0f, cubicBezierEasing);
+        sizeAnimation.Duration(Windows::Foundation::TimeSpan{ std::chrono::seconds(2) });
+        sizeAnimation.IterationBehavior(Windows::UI::Composition::AnimationIterationBehavior::Forever);
+
+        m_shape.StartAnimation(L"RotationAngleInDegrees", rotationAnimation);
+        ellipse.StartAnimation(L"TrimEnd", sizeAnimation);
+    }
+
+    Windows::Foundation::Size ProgressRing::MeasureOverride(Windows::Foundation::Size const& availableSize)
+    {
+        auto size = availableSize.Width > availableSize.Height ? availableSize.Height : availableSize.Width;
+        if (size == INFINITY)
+        {
+            size = m_defaultProgressRingSize;
+        }
+
+        return { size, size };
+    }
+
+    Windows::Foundation::Size ProgressRing::ArrangeOverride(Windows::Foundation::Size const& finalSize)
+    {
+        auto size = finalSize.Width > finalSize.Height ? finalSize.Height : finalSize.Width;
+
+        float scale = size / m_defaultProgressRingSize;
+        m_visual.Scale({ scale, scale, scale });
+
+        float widthOffset = (finalSize.Width - size) / 2;
+        float heightOffset = (finalSize.Height - size) / 2;
+        m_visual.Offset({ widthOffset, heightOffset, 0.0f });
+
+        return finalSize;
+    }
+
+    Windows::UI::Xaml::DependencyProperty ProgressRing::m_foregroundProperty =
+        Windows::UI::Xaml::DependencyProperty::Register(
+            L"Foreground",
+            winrt::xaml_typename<Windows::UI::Xaml::Media::SolidColorBrush>(),
+            winrt::xaml_typename<NanaBox::ProgressRing>(),
+            Windows::UI::Xaml::PropertyMetadata{ nullptr, &OnForegroundChanged }
+        );
+
+    void ProgressRing::OnForegroundChanged(Windows::UI::Xaml::DependencyObject d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs args)
+    {
+        auto progressRing = d.as<NanaBox::ProgressRing>();
+        auto progressRingImpl = winrt::get_self<NanaBox::implementation::ProgressRing>(progressRing);
+
+        auto oldBrush = progressRingImpl->m_shape.StrokeBrush();
+        auto newBrush = progressRingImpl->m_compositor.CreateColorBrush(args.NewValue().as<Windows::UI::Xaml::Media::SolidColorBrush>().Color());
+        progressRingImpl->m_shape.StrokeBrush(newBrush);
+
+        if (oldBrush)
+        {
+            oldBrush.Close();
+        }
+    }
+
+    Windows::UI::Xaml::DependencyProperty ProgressRing::ForegroundProperty()
+    {
+        return m_foregroundProperty;
+    }
+
+    Windows::UI::Xaml::Media::SolidColorBrush ProgressRing::Foreground()
+    {
+        return winrt::unbox_value<Windows::UI::Xaml::Media::SolidColorBrush>(GetValue(m_foregroundProperty));
+    }
+
+    void ProgressRing::Foreground(Windows::UI::Xaml::Media::SolidColorBrush const& value)
+    {
+        SetValue(m_foregroundProperty, value);
+    }
+}

--- a/NanaBox/ProgressRing.h
+++ b/NanaBox/ProgressRing.h
@@ -1,0 +1,37 @@
+﻿#pragma once
+
+#include "ProgressRing.g.h"
+#include <winrt/Windows.UI.Composition.h>
+
+namespace winrt::NanaBox::implementation
+{
+    struct ProgressRing : ProgressRingT<ProgressRing>
+    {
+        ProgressRing();
+
+        static Windows::UI::Xaml::DependencyProperty ForegroundProperty();
+        Windows::UI::Xaml::Media::SolidColorBrush Foreground();
+        void Foreground(Windows::UI::Xaml::Media::SolidColorBrush const& value);
+
+        Windows::Foundation::Size MeasureOverride(Windows::Foundation::Size const& availableSize);
+        Windows::Foundation::Size ArrangeOverride(Windows::Foundation::Size const& finalSize);
+
+    private:
+        static void OnForegroundChanged(Windows::UI::Xaml::DependencyObject d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs args);
+
+        Windows::UI::Composition::Compositor m_compositor{ nullptr };
+        Windows::UI::Composition::CompositionSpriteShape m_shape{ nullptr };
+        Windows::UI::Composition::ShapeVisual m_visual{ nullptr };
+
+        static Windows::UI::Xaml::DependencyProperty m_foregroundProperty;
+        const float m_defaultProgressRingSize = 80.0f;
+        const float m_strokeThickness = 1.5f;
+    };
+}
+
+namespace winrt::NanaBox::factory_implementation
+{
+    struct ProgressRing : ProgressRingT<ProgressRing, implementation::ProgressRing>
+    {
+    };
+}

--- a/NanaBox/ProgressRing.idl
+++ b/NanaBox/ProgressRing.idl
@@ -1,0 +1,9 @@
+﻿namespace NanaBox
+{
+    runtimeclass ProgressRing : Windows.UI.Xaml.FrameworkElement
+    {
+        ProgressRing();
+        static Windows.UI.Xaml.DependencyProperty ForegroundProperty { get; };
+        Windows.UI.Xaml.Media.SolidColorBrush Foreground;
+    }
+}

--- a/NanaBox/ResizeVirtualHardDiskPage.xaml
+++ b/NanaBox/ResizeVirtualHardDiskPage.xaml
@@ -1,98 +1,98 @@
 ﻿<Page
-    x:Class="NanaBox.ResizeVirtualHardDiskPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:NanaBox"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    IsTextScaleFactorEnabled="False"
-    mc:Ignorable="d">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <StackPanel Grid.Row="0" Padding="24,0">
-            <TextBlock
-                x:Uid="/ResizeVirtualHardDiskPage/GridTitleTextBlock"
-                Margin="0,0,0,12"
-                FontSize="24"
-                FontWeight="SemiBold"
-                Text="[Resize Virtual Hard Disk]"
-                TextWrapping="Wrap" />
-            <TextBlock
-                x:Uid="/ResizeVirtualHardDiskPage/ContentTextBlock"
-                Text="[Specify the new size for the virtual hard disk.]"
-                TextWrapping="Wrap" />
-            <Grid Padding="0,2,0,0" ColumnSpacing="8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="auto" />
-                </Grid.ColumnDefinitions>
-                <TextBox
-                    x:Name="FileNameTextBox"
-                    x:Uid="/ResizeVirtualHardDiskPage/FileNameTextBox"
-                    Grid.Column="0"
-                    IsReadOnly="True"
-                    PlaceholderText="[Please use &quot;...&quot; button to specify the save location.]" />
-                <Button
-                    x:Name="FileNameBrowseButton"
-                    Grid.Column="1"
-                    Click="FileNameBrowseButtonClickHandler"
-                    Content="..." />
-            </Grid>
-            <TextBlock
-                x:Uid="/ResizeVirtualHardDiskPage/SizeTextBlock"
-                Padding="0,2"
-                Text="[Size (at least 3 MiB and must be a multiple of 512 bytes)]" />
-            <Grid Padding="0,2,0,0" ColumnSpacing="8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="144" />
-                </Grid.ColumnDefinitions>
-                <TextBox
-                    x:Name="SizeTextBox"
-                    BeforeTextChanging="NaturalNumberTextBoxBeforeTextChanging"
-                    Text="0" />
-                <ComboBox
-                    x:Name="SizeUnitComboBox"
-                    Grid.Column="1"
-                    HorizontalAlignment="Stretch"
-                    SelectedIndex="5">
-                    <x:String>B</x:String>
-                    <x:String>KB (1000 B)</x:String>
-                    <x:String>KiB (1024 B)</x:String>
-                    <x:String>MB (1000 KB)</x:String>
-                    <x:String>MiB (1024 KiB)</x:String>
-                    <x:String>GB (1000 MB)</x:String>
-                    <x:String>GiB (1024 MiB)</x:String>
-                    <x:String>TB (1000 GB)</x:String>
-                    <x:String>TiB (1024 GiB)</x:String>
-                </ComboBox>
-            </Grid>
-        </StackPanel>
+  x:Class="NanaBox.ResizeVirtualHardDiskPage"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:local="using:NanaBox"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  IsTextScaleFactorEnabled="False"
+  mc:Ignorable="d">
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+    <StackPanel Grid.Row="0" Padding="24,0">
+      <TextBlock
+        x:Uid="/ResizeVirtualHardDiskPage/GridTitleTextBlock"
+        Margin="0,0,0,12"
+        FontSize="24"
+        FontWeight="SemiBold"
+        Text="[Resize Virtual Hard Disk]"
+        TextWrapping="Wrap" />
+      <TextBlock
+        x:Uid="/ResizeVirtualHardDiskPage/ContentTextBlock"
+        Text="[Specify the new size for the virtual hard disk.]"
+        TextWrapping="Wrap" />
+      <Grid Padding="0,2,0,0" ColumnSpacing="8">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="auto" />
+        </Grid.ColumnDefinitions>
+        <TextBox
+          x:Name="FileNameTextBox"
+          x:Uid="/ResizeVirtualHardDiskPage/FileNameTextBox"
+          Grid.Column="0"
+          IsReadOnly="True"
+          PlaceholderText="[Please use &quot;...&quot; button to specify the save location.]" />
+        <Button
+          x:Name="FileNameBrowseButton"
+          Grid.Column="1"
+          Click="FileNameBrowseButtonClickHandler"
+          Content="..." />
+      </Grid>
+      <TextBlock
+        x:Uid="/ResizeVirtualHardDiskPage/SizeTextBlock"
+        Padding="0,2"
+        Text="[Size (at least 3 MiB and must be a multiple of 512 bytes)]" />
+      <Grid Padding="0,2,0,0" ColumnSpacing="8">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="144" />
+        </Grid.ColumnDefinitions>
+        <TextBox
+          x:Name="SizeTextBox"
+          BeforeTextChanging="NaturalNumberTextBoxBeforeTextChanging"
+          Text="0" />
+        <ComboBox
+          x:Name="SizeUnitComboBox"
+          Grid.Column="1"
+          HorizontalAlignment="Stretch"
+          SelectedIndex="5">
+          <x:String>B</x:String>
+          <x:String>KB (1000 B)</x:String>
+          <x:String>KiB (1024 B)</x:String>
+          <x:String>MB (1000 KB)</x:String>
+          <x:String>MiB (1024 KiB)</x:String>
+          <x:String>GB (1000 MB)</x:String>
+          <x:String>GiB (1024 MiB)</x:String>
+          <x:String>TB (1000 GB)</x:String>
+          <x:String>TiB (1024 GiB)</x:String>
+        </ComboBox>
+      </Grid>
+    </StackPanel>
 
-        <Grid Grid.Row="1" Padding="24">
-            <Grid.Background>
-                <SolidColorBrush Opacity="0.2" Color="{ThemeResource SystemChromeHighColor}" />
-            </Grid.Background>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="8" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Button
-                x:Uid="/ResizeVirtualHardDiskPage/ResizeButton"
-                HorizontalAlignment="Stretch"
-                Click="ResizeButtonClick"
-                Content="[Resize]" />
-            <Button
-                x:Uid="/ResizeVirtualHardDiskPage/CancelButton"
-                Grid.Column="2"
-                HorizontalAlignment="Stretch"
-                Click="CancelButtonClick"
-                Content="[Cancel]"
-                TabIndex="1" />
-        </Grid>
+    <Grid Grid.Row="1" Padding="24">
+      <Grid.Background>
+        <SolidColorBrush Opacity="0.2" Color="{ThemeResource SystemChromeHighColor}" />
+      </Grid.Background>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="8" />
+        <ColumnDefinition Width="*" />
+      </Grid.ColumnDefinitions>
+      <Button
+        x:Uid="/ResizeVirtualHardDiskPage/ResizeButton"
+        HorizontalAlignment="Stretch"
+        Click="ResizeButtonClick"
+        Content="[Resize]" />
+      <Button
+        x:Uid="/ResizeVirtualHardDiskPage/CancelButton"
+        Grid.Column="2"
+        HorizontalAlignment="Stretch"
+        Click="CancelButtonClick"
+        Content="[Cancel]"
+        TabIndex="1" />
     </Grid>
+  </Grid>
 </Page>

--- a/NanaBox/ResizeVirtualHardDiskPage.xaml
+++ b/NanaBox/ResizeVirtualHardDiskPage.xaml
@@ -1,98 +1,98 @@
 ﻿<Page
-  x:Class="NanaBox.ResizeVirtualHardDiskPage"
-  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-  xmlns:local="using:NanaBox"
-  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-  IsTextScaleFactorEnabled="False"
-  mc:Ignorable="d">
-  <Grid>
-    <Grid.RowDefinitions>
-      <RowDefinition Height="*" />
-      <RowDefinition Height="Auto" />
-    </Grid.RowDefinitions>
-    <StackPanel Grid.Row="0" Padding="24,0">
-      <TextBlock
-        x:Uid="/ResizeVirtualHardDiskPage/GridTitleTextBlock"
-        Margin="0,0,0,12"
-        FontSize="24"
-        FontWeight="SemiBold"
-        Text="[Resize Virtual Hard Disk]"
-        TextWrapping="Wrap" />
-      <TextBlock
-        x:Uid="/ResizeVirtualHardDiskPage/ContentTextBlock"
-        Text="[Specify the new size for the virtual hard disk.]"
-        TextWrapping="Wrap" />
-      <Grid Padding="0,2,0,0">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="auto" />
-        </Grid.ColumnDefinitions>
-        <TextBox
-          x:Name="FileNameTextBox"
-          x:Uid="/ResizeVirtualHardDiskPage/FileNameTextBox"
-          Grid.Column="0"
-          IsReadOnly="True"
-          PlaceholderText="[Please use &quot;...&quot; button to specify the save location.]" />
-        <Button
-          x:Name="FileNameBrowseButton"
-          Grid.Column="1"
-          Click="FileNameBrowseButtonClickHandler"
-          Content="..." />
-      </Grid>
-      <TextBlock
-        x:Uid="/ResizeVirtualHardDiskPage/SizeTextBlock"
-        Padding="0,2"
-        Text="[Size (at least 3 MiB and must be a multiple of 512 bytes)]" />
-      <Grid Padding="0,2,0,0">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="144" />
-        </Grid.ColumnDefinitions>
-        <TextBox
-          x:Name="SizeTextBox"
-          BeforeTextChanging="NaturalNumberTextBoxBeforeTextChanging"
-          Text="0" />
-        <ComboBox
-          x:Name="SizeUnitComboBox"
-          Grid.Column="1"
-          HorizontalAlignment="Stretch"
-          SelectedIndex="5">
-          <x:String>B</x:String>
-          <x:String>KB (1000 B)</x:String>
-          <x:String>KiB (1024 B)</x:String>
-          <x:String>MB (1000 KB)</x:String>
-          <x:String>MiB (1024 KiB)</x:String>
-          <x:String>GB (1000 MB)</x:String>
-          <x:String>GiB (1024 MiB)</x:String>
-          <x:String>TB (1000 GB)</x:String>
-          <x:String>TiB (1024 GiB)</x:String>
-        </ComboBox>
-      </Grid>
-    </StackPanel>
+    x:Class="NanaBox.ResizeVirtualHardDiskPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:NanaBox"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    IsTextScaleFactorEnabled="False"
+    mc:Ignorable="d">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Padding="24,0">
+            <TextBlock
+                x:Uid="/ResizeVirtualHardDiskPage/GridTitleTextBlock"
+                Margin="0,0,0,12"
+                FontSize="24"
+                FontWeight="SemiBold"
+                Text="[Resize Virtual Hard Disk]"
+                TextWrapping="Wrap" />
+            <TextBlock
+                x:Uid="/ResizeVirtualHardDiskPage/ContentTextBlock"
+                Text="[Specify the new size for the virtual hard disk.]"
+                TextWrapping="Wrap" />
+            <Grid Padding="0,2,0,0" ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="auto" />
+                </Grid.ColumnDefinitions>
+                <TextBox
+                    x:Name="FileNameTextBox"
+                    x:Uid="/ResizeVirtualHardDiskPage/FileNameTextBox"
+                    Grid.Column="0"
+                    IsReadOnly="True"
+                    PlaceholderText="[Please use &quot;...&quot; button to specify the save location.]" />
+                <Button
+                    x:Name="FileNameBrowseButton"
+                    Grid.Column="1"
+                    Click="FileNameBrowseButtonClickHandler"
+                    Content="..." />
+            </Grid>
+            <TextBlock
+                x:Uid="/ResizeVirtualHardDiskPage/SizeTextBlock"
+                Padding="0,2"
+                Text="[Size (at least 3 MiB and must be a multiple of 512 bytes)]" />
+            <Grid Padding="0,2,0,0" ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="144" />
+                </Grid.ColumnDefinitions>
+                <TextBox
+                    x:Name="SizeTextBox"
+                    BeforeTextChanging="NaturalNumberTextBoxBeforeTextChanging"
+                    Text="0" />
+                <ComboBox
+                    x:Name="SizeUnitComboBox"
+                    Grid.Column="1"
+                    HorizontalAlignment="Stretch"
+                    SelectedIndex="5">
+                    <x:String>B</x:String>
+                    <x:String>KB (1000 B)</x:String>
+                    <x:String>KiB (1024 B)</x:String>
+                    <x:String>MB (1000 KB)</x:String>
+                    <x:String>MiB (1024 KiB)</x:String>
+                    <x:String>GB (1000 MB)</x:String>
+                    <x:String>GiB (1024 MiB)</x:String>
+                    <x:String>TB (1000 GB)</x:String>
+                    <x:String>TiB (1024 GiB)</x:String>
+                </ComboBox>
+            </Grid>
+        </StackPanel>
 
-    <Grid Grid.Row="1" Padding="24">
-      <Grid.Background>
-        <SolidColorBrush Opacity="0.2" Color="{ThemeResource SystemChromeHighColor}" />
-      </Grid.Background>
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="*" />
-        <ColumnDefinition Width="8" />
-        <ColumnDefinition Width="*" />
-      </Grid.ColumnDefinitions>
-      <Button
-        x:Uid="/ResizeVirtualHardDiskPage/ResizeButton"
-        HorizontalAlignment="Stretch"
-        Click="ResizeButtonClick"
-        Content="[Resize]" />
-      <Button
-        x:Uid="/ResizeVirtualHardDiskPage/CancelButton"
-        Grid.Column="2"
-        HorizontalAlignment="Stretch"
-        Click="CancelButtonClick"
-        Content="[Cancel]"
-        TabIndex="1" />
+        <Grid Grid.Row="1" Padding="24">
+            <Grid.Background>
+                <SolidColorBrush Opacity="0.2" Color="{ThemeResource SystemChromeHighColor}" />
+            </Grid.Background>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="8" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Button
+                x:Uid="/ResizeVirtualHardDiskPage/ResizeButton"
+                HorizontalAlignment="Stretch"
+                Click="ResizeButtonClick"
+                Content="[Resize]" />
+            <Button
+                x:Uid="/ResizeVirtualHardDiskPage/CancelButton"
+                Grid.Column="2"
+                HorizontalAlignment="Stretch"
+                Click="CancelButtonClick"
+                Content="[Cancel]"
+                TabIndex="1" />
+        </Grid>
     </Grid>
-  </Grid>
 </Page>

--- a/NanaBox/Utils.cpp
+++ b/NanaBox/Utils.cpp
@@ -29,7 +29,7 @@ namespace winrt
     using Windows::UI::Xaml::HorizontalAlignment;
     using Windows::UI::Xaml::ThicknessHelper;
     using Windows::UI::Xaml::VerticalAlignment;
-    using Windows::UI::Xaml::Controls::ProgressRing;
+    using NanaBox::ProgressRing;
 }
 
 void SplitCommandLineEx(
@@ -937,7 +937,7 @@ HWND ShowOperationWaitingWindow(
         Content.Margin(winrt::ThicknessHelper::FromUniformLength(12));
         Content.HorizontalAlignment(winrt::HorizontalAlignment::Stretch);
         Content.VerticalAlignment(winrt::VerticalAlignment::Stretch);
-        Content.IsActive(true);
+        // Content.IsActive(true);
 
         ::ShowXamlDialog(
             WindowHandle,


### PR DESCRIPTION
- Use the Windows 11 style `ProgressRing`.
- Change the padding between the text boxes and buttons/combo boxes to 8px, which follows the WinUI design guidance.
  + I haven't change the padding of the text blocks due to height constraints.

> [!NOTE]
> I would recommend viewing the changes with whitespaces disabled.