### PR TITLE
Remove UTF-8 signature from schema and COMMIT_EDITMSG

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -57,3 +57,9 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.json]
+charset = utf-8
+
+[COMMIT_EDITMSG]
+charset = utf-8

--- a/Documents/ConfigurationSchema.json
+++ b/Documents/ConfigurationSchema.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "NanaBox configuration file",
   "description": "Schema for NanaBox configuration files (*.7b)",


### PR DESCRIPTION
VSCode cannot load schemas with BOM.