### PR TITLE
Add mitigation for DLL sideloading

### DIFF
--- a/NanaBox/NanaBox.cpp
+++ b/NanaBox/NanaBox.cpp
@@ -87,6 +87,8 @@ int WINAPI wWinMain(
     UNREFERENCED_PARAMETER(hPrevInstance);
     UNREFERENCED_PARAMETER(lpCmdLine);
 
+    ::SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32);
+
     winrt::init_apartment(winrt::apartment_type::single_threaded);
 
     winrt::check_hresult(::SetCurrentProcessExplicitAppUserModelID(

--- a/NanaBox/NanaBox.vcxproj
+++ b/NanaBox/NanaBox.vcxproj
@@ -45,6 +45,9 @@
       <RuntimeLibrary Condition="'$(Configuration)' == 'Debug'">MultiThreadedDebug</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(Configuration)' == 'Release'">MultiThreaded</RuntimeLibrary>
     </ClCompile>
+    <Link Condition="'$(Configuration)' == 'Release'">
+      <AdditionalOptions>%(AdditionalOptions) /DEPENDENTLOADFLAG:0x800</AdditionalOptions>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AboutPage.cpp">


### PR DESCRIPTION
* Set /DEPENDENTLOADFLAG:0x800 to force static dependencies to load from System32.
* Call SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32) to enforce the same requirements for dynamically-loaded DLLs.

Note: From manual testing, SetDefaultDllDirectories was sufficient and so DelayLoadDLLs was not needed.